### PR TITLE
Add the add-a-link button

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2024-06-16T18:32:35.051948Z">
+        <DropdownSelection timestamp="2024-06-16T21:54:27.747581Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/Users/sweis/.android/avd/Pixel_8_API_UpsideDownCakePrivacySandbox.avd" />

--- a/app/src/main/java/com/example/volcanoseason3/MainActivity.kt
+++ b/app/src/main/java/com/example/volcanoseason3/MainActivity.kt
@@ -97,7 +97,11 @@ class MainActivity : AppCompatActivity() {
                     else -> ""
                 }
                 val combinedName = "$selectedRadio $name"
-                addLinkToHomeFragment(combinedName, link)
+                if (isValidUrl(link)) {
+                    addLinkToHomeFragment(combinedName, link)
+                } else {
+                    Snackbar.make(binding.root, "Invalid URL. Please try again", Snackbar.LENGTH_LONG).show()
+                }
                 dialog.dismiss()
             }
             .setNegativeButton("Cancel") { dialog, _ ->
@@ -113,5 +117,9 @@ class MainActivity : AppCompatActivity() {
         val homeFragment =
             navHostFragment.childFragmentManager.fragments.find { it is HomeFragment } as? HomeFragment
         homeFragment?.addLink(name, link)
+    }
+
+    private fun isValidUrl(url: String): Boolean {
+        return android.util.Patterns.WEB_URL.matcher(url).matches()
     }
 }

--- a/app/src/main/java/com/example/volcanoseason3/MainActivity.kt
+++ b/app/src/main/java/com/example/volcanoseason3/MainActivity.kt
@@ -27,7 +27,7 @@ class MainActivity : AppCompatActivity() {
         setSupportActionBar(binding.appBarMain.toolbar)
 
         binding.appBarMain.fab.setOnClickListener { view ->
-            Snackbar.make(view, "Replace with your own action", Snackbar.LENGTH_LONG)
+            Snackbar.make(view, "Replace with your own action !!!!!", Snackbar.LENGTH_LONG)
                 .setAction("Action", null).show()
         }
         val drawerLayout: DrawerLayout = binding.drawerLayout

--- a/app/src/main/java/com/example/volcanoseason3/MainActivity.kt
+++ b/app/src/main/java/com/example/volcanoseason3/MainActivity.kt
@@ -2,7 +2,10 @@ package com.example.volcanoseason3
 
 import android.os.Bundle
 import android.util.Log
+import android.view.LayoutInflater
 import android.view.Menu
+import android.widget.EditText
+import androidx.appcompat.app.AlertDialog
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.navigation.NavigationView
 import androidx.navigation.findNavController
@@ -12,8 +15,10 @@ import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.appcompat.app.AppCompatActivity
+import androidx.navigation.fragment.NavHostFragment
 import com.example.volcanoseason3.databinding.ActivityMainBinding
 import com.example.volcanoseason3.databinding.FragmentHomeBinding
+import com.example.volcanoseason3.ui.home.HomeFragment
 import com.example.volcanoseason3.ui.home.HomeViewModel
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 
@@ -33,6 +38,7 @@ class MainActivity : AppCompatActivity() {
         binding.appBarMain.fab.setOnClickListener { view ->
             Snackbar.make(view, "Replace with your own action !!!!!", Snackbar.LENGTH_LONG)
                 .setAction("Action", null).show()
+            showAddLinkDialog()
         }
         val drawerLayout: DrawerLayout = binding.drawerLayout
         val navView: NavigationView = binding.navView
@@ -66,5 +72,34 @@ class MainActivity : AppCompatActivity() {
     override fun onSupportNavigateUp(): Boolean {
         val navController = findNavController(R.id.nav_host_fragment_content_main)
         return navController.navigateUp(appBarConfiguration) || super.onSupportNavigateUp()
+    }
+
+    private fun showAddLinkDialog(): Unit {
+        val dialogView = LayoutInflater.from(this).inflate(R.layout.dialog_add_link, null)
+        val editTextName = dialogView.findViewById<EditText>(R.id.edit_text_name)
+        val editTextLink = dialogView.findViewById<EditText>(R.id.edit_text_link)
+
+        AlertDialog.Builder(this)
+            .setTitle("Add a mountain")
+            .setView(dialogView)
+            .setPositiveButton("Add") { dialog, _ ->
+                val name = editTextName.text.toString()
+                val link = editTextLink.text.toString()
+                addLinkToHomeFragment(name, link)
+                dialog.dismiss()
+            }
+            .setNegativeButton("Cancel") { dialog, _ ->
+                dialog.dismiss()
+            }
+            .create()
+            .show()
+    }
+
+    private fun addLinkToHomeFragment(name: String, link: String) {
+        val navHostFragment =
+            supportFragmentManager.findFragmentById(R.id.nav_host_fragment_content_main) as NavHostFragment
+        val homeFragment =
+            navHostFragment.childFragmentManager.fragments.find { it is HomeFragment } as? HomeFragment
+        homeFragment?.addLink(name, link)
     }
 }

--- a/app/src/main/java/com/example/volcanoseason3/MainActivity.kt
+++ b/app/src/main/java/com/example/volcanoseason3/MainActivity.kt
@@ -1,10 +1,13 @@
 package com.example.volcanoseason3
 
 import android.os.Bundle
+import android.provider.MediaStore.Audio.Radio
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.Menu
 import android.widget.EditText
+import android.widget.RadioButton
+import android.widget.RadioGroup
 import androidx.appcompat.app.AlertDialog
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.navigation.NavigationView
@@ -78,6 +81,9 @@ class MainActivity : AppCompatActivity() {
         val dialogView = LayoutInflater.from(this).inflate(R.layout.dialog_add_link, null)
         val editTextName = dialogView.findViewById<EditText>(R.id.edit_text_name)
         val editTextLink = dialogView.findViewById<EditText>(R.id.edit_text_link)
+        val radioGroupOptions = dialogView.findViewById<RadioGroup>(R.id.radioGroupOptions)
+        val radioButtonVolcano = dialogView.findViewById<RadioButton>(R.id.radio_button_volcano)
+        val radioButtonRegion = dialogView.findViewById<RadioButton>(R.id.radio_button_region)
 
         AlertDialog.Builder(this)
             .setTitle("Add a mountain")
@@ -85,7 +91,13 @@ class MainActivity : AppCompatActivity() {
             .setPositiveButton("Add") { dialog, _ ->
                 val name = editTextName.text.toString()
                 val link = editTextLink.text.toString()
-                addLinkToHomeFragment(name, link)
+                val selectedRadio = when (radioGroupOptions.checkedRadioButtonId) {
+                    R.id.radio_button_volcano -> getString(R.string.emoji_volcano)
+                    R.id.radio_button_region -> getString(R.string.emoji_region)
+                    else -> ""
+                }
+                val combinedName = "$selectedRadio $name"
+                addLinkToHomeFragment(combinedName, link)
                 dialog.dismiss()
             }
             .setNegativeButton("Cancel") { dialog, _ ->

--- a/app/src/main/java/com/example/volcanoseason3/MainActivity.kt
+++ b/app/src/main/java/com/example/volcanoseason3/MainActivity.kt
@@ -39,10 +39,9 @@ class MainActivity : AppCompatActivity() {
         setSupportActionBar(binding.appBarMain.toolbar)
 
         binding.appBarMain.fab.setOnClickListener { view ->
-            Snackbar.make(view, "Replace with your own action !!!!!", Snackbar.LENGTH_LONG)
-                .setAction("Action", null).show()
             showAddLinkDialog()
         }
+
         val drawerLayout: DrawerLayout = binding.drawerLayout
         val navView: NavigationView = binding.navView
         val navController = findNavController(R.id.nav_host_fragment_content_main)

--- a/app/src/main/java/com/example/volcanoseason3/MainActivity.kt
+++ b/app/src/main/java/com/example/volcanoseason3/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.example.volcanoseason3
 
 import android.os.Bundle
+import android.util.Log
 import android.view.Menu
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.navigation.NavigationView
@@ -12,6 +13,9 @@ import androidx.navigation.ui.setupWithNavController
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.appcompat.app.AppCompatActivity
 import com.example.volcanoseason3.databinding.ActivityMainBinding
+import com.example.volcanoseason3.databinding.FragmentHomeBinding
+import com.example.volcanoseason3.ui.home.HomeViewModel
+import com.google.android.material.floatingactionbutton.FloatingActionButton
 
 class MainActivity : AppCompatActivity() {
 

--- a/app/src/main/java/com/example/volcanoseason3/MainActivity.kt
+++ b/app/src/main/java/com/example/volcanoseason3/MainActivity.kt
@@ -46,6 +46,15 @@ class MainActivity : AppCompatActivity() {
         )
         setupActionBarWithNavController(navController, appBarConfiguration)
         navView.setupWithNavController(navController)
+
+        // Add a destination listener to control FAB visibility.
+        navController.addOnDestinationChangedListener { _, dest, _ ->
+            if (dest.id == R.id.nav_home) {
+                binding.appBarMain.fab.show()
+            } else {
+                binding.appBarMain.fab.hide()
+            }
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/app/src/main/java/com/example/volcanoseason3/ui/checklist/ChecklistFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/checklist/ChecklistFragment.kt
@@ -1,16 +1,17 @@
 package com.example.volcanoseason3.ui.checklist
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.findFragment
 import androidx.lifecycle.ViewModelProvider
 import com.example.volcanoseason3.databinding.FragmentChecklistBinding
 
 class ChecklistFragment : Fragment() {
-
     private var _binding: FragmentChecklistBinding? = null
 
     // This property is only valid between onCreateView and
@@ -22,14 +23,14 @@ class ChecklistFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val slideshowViewModel =
+        val checklistViewModel =
             ViewModelProvider(this).get(ChecklistViewModel::class.java)
 
         _binding = FragmentChecklistBinding.inflate(inflater, container, false)
         val root: View = binding.root
 
         val textView: TextView = binding.textChecklist
-        slideshowViewModel.text.observe(viewLifecycleOwner) {
+        checklistViewModel.text.observe(viewLifecycleOwner) {
             textView.text = it
         }
         return root

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -1,6 +1,7 @@
 package com.example.volcanoseason3.ui.home
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -36,6 +37,10 @@ class HomeFragment : Fragment() {
         binding.lvForecastList.adapter = adapter
 
         return root
+    }
+
+    fun addLink(name: String, link: String) {
+        Log.d("HomeFragment", "Adding link for mountain: $name, $link")
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.textclassifier.TextLinks
 import androidx.fragment.app.Fragment
 import com.example.volcanoseason3.R
 import com.example.volcanoseason3.data.gallery.MountainLink
@@ -18,6 +19,9 @@ class HomeFragment : Fragment() {
     // onDestroyView.
     private val binding get() = _binding!!
 
+    private lateinit var mountainLinks: ArrayList<MountainLink>
+    private lateinit var adapter: MountainLinkAdapter
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -29,11 +33,11 @@ class HomeFragment : Fragment() {
         val linkNames : Array<String> = resources.getStringArray(R.array.forecast_link_names)
         val links : Array<String> = resources.getStringArray(R.array.forecast_links)
 
-        val mountainLinks = ArrayList(
+        mountainLinks = ArrayList(
             linkNames.zip(links) { name, link -> MountainLink(name, link) }.toList()
         )
 
-        val adapter = MountainLinkAdapter(requireContext(), mountainLinks)
+        adapter = MountainLinkAdapter(requireContext(), mountainLinks)
         binding.lvForecastList.adapter = adapter
 
         return root
@@ -41,6 +45,9 @@ class HomeFragment : Fragment() {
 
     fun addLink(name: String, link: String) {
         Log.d("HomeFragment", "Adding link for mountain: $name, $link")
+        val newMountainLink = MountainLink(name, link)
+        mountainLinks.add(newMountainLink)
+        adapter.notifyDataSetChanged()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -46,7 +46,8 @@ class HomeFragment : Fragment() {
     fun addLink(name: String, link: String) {
         Log.d("HomeFragment", "Adding link for mountain: $name, $link")
         val newMountainLink = MountainLink(name, link)
-        mountainLinks.add(newMountainLink)
+        // Temporary organization adds the new link to the 2nd to last index
+        mountainLinks.add(mountainLinks.size - 1, newMountainLink)
         adapter.notifyDataSetChanged()
     }
 

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/MountainLinkAdapter.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/MountainLinkAdapter.kt
@@ -36,16 +36,35 @@ class MountainLinkAdapter(
 
         // Set the link of the mountain to the click listener
         listItemView.setOnClickListener {
-            Snackbar.make(
-                listItemView,
-                "Navigating to ${currentMountain.name} forecast",
-                Snackbar.LENGTH_LONG
-            ).show()
-            val intent = Intent(Intent.ACTION_VIEW)
-            intent.setData(Uri.parse(currentMountain.link))
-            listItemView.context.startActivity(intent)
+            if (isValidUrl(currentMountain.link)) {
+                Snackbar.make(
+                    listItemView,
+                    "Navigating to ${currentMountain.name} forecast",
+                    Snackbar.LENGTH_LONG
+                ).show()
+                try {
+                    val intent = Intent(Intent.ACTION_VIEW)
+                    intent.setData(Uri.parse(currentMountain.link))
+                    listItemView.context.startActivity(intent)
+                } catch (e: Exception) {
+                    Snackbar.make(
+                        listItemView,
+                        "No application can handle this request. Please install a web browser or check the URL.",
+                        Snackbar.LENGTH_LONG
+                    ).show()
+                }
+            } else {
+                Snackbar.make(
+                    listItemView,
+                    "Invalid URL. Cannot navigate to ${currentMountain.name} forecast.",
+                    Snackbar.LENGTH_LONG
+                ).show()
+            }
         }
-
         return listItemView
+    }
+
+    private fun isValidUrl(url: String): Boolean {
+        return android.util.Patterns.WEB_URL.matcher(url).matches()
     }
 }

--- a/app/src/main/res/drawable/baseline_add_link_24.xml
+++ b/app/src/main/res/drawable/baseline_add_link_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M8,11h8v2L8,13zM20.1,12L22,12c0,-2.76 -2.24,-5 -5,-5h-4v1.9h4c1.71,0 3.1,1.39 3.1,3.1zM3.9,12c0,-1.71 1.39,-3.1 3.1,-3.1h4L11,7L7,7c-2.76,0 -5,2.24 -5,5s2.24,5 5,5h4v-1.9L7,15.1c-1.71,0 -3.1,-1.39 -3.1,-3.1zM19,12h-2v3h-3v2h3v3h2v-3h3v-2h-3z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/baseline_add_link_24.xml
+++ b/app/src/main/res/drawable/baseline_add_link_24.xml
@@ -1,4 +1,4 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
       
     <path android:fillColor="@android:color/white" android:pathData="M8,11h8v2L8,13zM20.1,12L22,12c0,-2.76 -2.24,-5 -5,-5h-4v1.9h4c1.71,0 3.1,1.39 3.1,3.1zM3.9,12c0,-1.71 1.39,-3.1 3.1,-3.1h4L11,7L7,7c-2.76,0 -5,2.24 -5,5s2.24,5 5,5h4v-1.9L7,15.1c-1.71,0 -3.1,-1.39 -3.1,-3.1zM19,12h-2v3h-3v2h3v3h2v-3h3v-2h-3z"/>
     

--- a/app/src/main/res/layout/app_bar_main.xml
+++ b/app/src/main/res/layout/app_bar_main.xml
@@ -29,6 +29,7 @@
         android:layout_gravity="bottom|end"
         android:layout_marginEnd="@dimen/fab_margin"
         android:layout_marginBottom="16dp"
-        app:srcCompat="@android:drawable/ic_dialog_email" />
+        android:backgroundTint="@color/light_blue"
+        app:srcCompat="@drawable/baseline_add_link_24" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/dialog_add_link.xml
+++ b/app/src/main/res/layout/dialog_add_link.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="16dp">
+    
+    <EditText
+        android:id="@+id/edit_text_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/dialog_name"/>
+    
+    <EditText
+        android:id="@+id/edit_text_link"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/dialog_link"
+        android:inputType="textUri"/>
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_add_link.xml
+++ b/app/src/main/res/layout/dialog_add_link.xml
@@ -18,4 +18,23 @@
         android:hint="@string/dialog_link"
         android:inputType="textUri"/>
 
+    <RadioGroup
+        android:id="@+id/radioGroupOptions"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <RadioButton
+            android:id="@+id/radio_button_volcano"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/dialog_radio_volcano" />
+
+        <RadioButton
+            android:id="@+id/radio_button_region"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/dialog_radio_region" />
+    </RadioGroup>
+
 </LinearLayout>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -8,7 +8,7 @@
         <!-- Secondary brand color. -->
         <item name="colorSecondary">@color/teal_200</item>
         <item name="colorSecondaryVariant">@color/teal_200</item>
-        <item name="colorOnSecondary">@color/black</item>
+        <item name="colorOnSecondary">@color/white</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
+<!DOCTYPE resources [
+    <!ENTITY volcano "\uD83C\uDF0B">
+    <!ENTITY sun_clouds "\uD83C\uDF24">
+]>
 <resources>
     <string name="app_name">VolcanoSeason3</string>
     <string name="navigation_drawer_open">Open navigation drawer</string>
@@ -11,20 +15,38 @@
     <string name="menu_home_links">Home - Choose a Forecast</string>
     <string name="menu_checklist">Equipment Checklist</string>
 
+    <string name="emoji_volcano">&volcano;</string>
+    <string name="emoji_region">&sun_clouds;</string>
+
+<!--    <string-array name="forecast_link_names">-->
+<!--        <item>\uD83C\uDF0B Mt Adams"</item>-->
+<!--        <item>\uD83C\uDF0B Mount Bachelor"</item>-->
+<!--        <item>\uD83C\uDF0B Broken Top"</item>-->
+<!--        <item>\uD83C\uDF0B Diamond Peak"</item>-->
+<!--        <item>\uD83C\uDF0B Mt Hood"</item>-->
+<!--        <item>\uD83C\uDF0B Lassen Peak"</item>-->
+<!--        <item>\uD83C\uDF0B Mount McLoughlin"</item>-->
+<!--        <item>\uD83C\uDF0B Mt Shasta"</item>-->
+<!--        <item>\uD83C\uDF0B Mt St Helens"</item>-->
+<!--        <item>\uD83C\uDF0B Mt Thielsen"</item>-->
+<!--        <item>\uD83C\uDF0B Three Sisters"</item>-->
+<!--        <item>\uD83C\uDF0B Mt Washington"</item>-->
+<!--        <item>🌤️  Bend NOAA</item>-->
+<!--    </string-array>-->
     <string-array name="forecast_link_names">
-        <item>\uD83C\uDF0B Mt Adams"</item>
-        <item>\uD83C\uDF0B Mount Bachelor"</item>
-        <item>\uD83C\uDF0B Broken Top"</item>
-        <item>\uD83C\uDF0B Diamond Peak"</item>
-        <item>\uD83C\uDF0B Mt Hood"</item>
-        <item>\uD83C\uDF0B Lassen Peak"</item>
-        <item>\uD83C\uDF0B Mount McLoughlin"</item>
-        <item>\uD83C\uDF0B Mt Shasta"</item>
-        <item>\uD83C\uDF0B Mt St Helens"</item>
-        <item>\uD83C\uDF0B Mt Thielsen"</item>
-        <item>\uD83C\uDF0B Three Sisters"</item>
-        <item>\uD83C\uDF0B Mt Washington"</item>
-        <item>🌤️  Bend NOAA</item>
+        <item>&volcano; Mt Adams"</item>
+        <item>&volcano; Mount Bachelor"</item>
+        <item>&volcano; Broken Top"</item>
+        <item>&volcano; Diamond Peak"</item>
+        <item>&volcano; Mt Hood"</item>
+        <item>&volcano; Lassen Peak"</item>
+        <item>&volcano; Mount McLoughlin"</item>
+        <item>&volcano; Mt Shasta"</item>
+        <item>&volcano; Mt St Helens"</item>
+        <item>&volcano; Mt Thielsen"</item>
+        <item>&volcano; Three Sisters"</item>
+        <item>&volcano; Mt Washington"</item>
+        <item>&sun_clouds; Bend NOAA</item>
     </string-array>
 
     <string-array name="forecast_links">
@@ -45,5 +67,7 @@
 
     <string name="dialog_name">Mountain Name</string>
     <string name="dialog_link">Forecast Link</string>
+    <string name="dialog_radio_volcano">&volcano; Volcano</string>
+    <string name="dialog_radio_region">&sun_clouds; Region</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,4 +43,7 @@
         <item>https://forecast.weather.gov/MapClick.php?lat=44.06&amp;lon=-121.3#.YsZ5b-zMLeo</item>
     </string-array>
 
+    <string name="dialog_name">Mountain Name</string>
+    <string name="dialog_link">Forecast Link</string>
+
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -8,7 +8,7 @@
         <!-- Secondary brand color. -->
         <item name="colorSecondary">@color/teal_200</item>
         <item name="colorSecondaryVariant">@color/teal_700</item>
-        <item name="colorOnSecondary">@color/black</item>
+        <item name="colorOnSecondary">@color/white</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->


### PR DESCRIPTION
## What's new?
- The template Floating Action Button (FAB) appearance is changed to better represent the apps goals (logo changed form main icon to add a link icon, colors changed, etc.)
- The FAB now only shows on the home screen (forecast lists) and not on the Equipment Checklist screen
- The FAB opens a dialog window where the user can enter new forecast link info. including name, URL, and type (volcano vs region radio buttons)
- URL format validation and error handling is incorporated to prevent the app from crashing due to a bad link entered by the user. 

<img width="196" alt="image" src="https://github.com/sweisss/VolcanoSeason3/assets/77857322/64f9f9ec-ac31-496a-a0bc-07447412654b">

<img width="265" alt="image" src="https://github.com/sweisss/VolcanoSeason3/assets/77857322/f9bc4d64-a88f-4ba6-944a-f973c14a3fd2">


Closes #4 