### PR TITLE
Add local storage

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2024-06-19T20:09:44.447560Z">
+        <DropdownSelection timestamp="2024-06-22T00:33:19.120814Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/Users/sweis/.android/avd/Pixel_8_API_UpsideDownCakePrivacySandbox.avd" />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("com.google.devtools.ksp") version "1.9.22-1.0.17"
 }
 
 android {
@@ -48,6 +49,10 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0")
     implementation("androidx.navigation:navigation-fragment-ktx:2.7.7")
     implementation("androidx.navigation:navigation-ui-ktx:2.7.7")
+    implementation("com.google.devtools.ksp:symbol-processing-api:2.0.0-1.0.22")
+    implementation("androidx.room:room-runtime:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
+    ksp("androidx.room:room-compiler:2.6.1")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/java/com/example/volcanoseason3/MainActivity.kt
+++ b/app/src/main/java/com/example/volcanoseason3/MainActivity.kt
@@ -85,7 +85,7 @@ class MainActivity : AppCompatActivity() {
         val radioButtonRegion = dialogView.findViewById<RadioButton>(R.id.radio_button_region)
 
         AlertDialog.Builder(this)
-            .setTitle("Add a mountain")
+            .setTitle(getString(R.string.dialog_title))
             .setView(dialogView)
             .setPositiveButton("Add") { dialog, _ ->
                 val name = editTextName.text.toString()

--- a/app/src/main/java/com/example/volcanoseason3/data/gallery/AppDatabase.kt
+++ b/app/src/main/java/com/example/volcanoseason3/data/gallery/AppDatabase.kt
@@ -1,0 +1,32 @@
+package com.example.volcanoseason3.data.gallery
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+const val DATABASE_NAME = "forecast-links-db"
+
+@Database(entities = [ForecastLink::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun forecastLinkDao() : ForecastLinkDao
+
+    companion object {
+        @Volatile private var instance: AppDatabase? = null
+
+        private fun buildDatabase(context: Context) =
+            Room.databaseBuilder(
+                context,
+                AppDatabase::class.java,
+                DATABASE_NAME
+            ).build()
+
+        fun getInstance(context: Context) : AppDatabase {
+            return  instance ?: synchronized(this) {
+                instance ?: buildDatabase(context).also {
+                    instance = it
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/volcanoseason3/data/gallery/ForecastLink.kt
+++ b/app/src/main/java/com/example/volcanoseason3/data/gallery/ForecastLink.kt
@@ -4,7 +4,7 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 
 @Entity
-data class MountainLink(
+data class ForecastLink(
     @PrimaryKey val name: String,
-    val link: String
+    val url: String
 )

--- a/app/src/main/java/com/example/volcanoseason3/data/gallery/ForecastLinkDao.kt
+++ b/app/src/main/java/com/example/volcanoseason3/data/gallery/ForecastLinkDao.kt
@@ -1,0 +1,14 @@
+package com.example.volcanoseason3.data.gallery
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+
+@Dao
+interface ForecastLinkDao {
+    @Insert
+    suspend fun insert(link: MountainLink)
+
+    @Delete
+    suspend fun delete(link: MountainLink)
+}

--- a/app/src/main/java/com/example/volcanoseason3/data/gallery/ForecastLinkDao.kt
+++ b/app/src/main/java/com/example/volcanoseason3/data/gallery/ForecastLinkDao.kt
@@ -7,8 +7,8 @@ import androidx.room.Insert
 @Dao
 interface ForecastLinkDao {
     @Insert
-    suspend fun insert(link: MountainLink)
+    suspend fun insert(link: ForecastLink)
 
     @Delete
-    suspend fun delete(link: MountainLink)
+    suspend fun delete(link: ForecastLink)
 }

--- a/app/src/main/java/com/example/volcanoseason3/data/gallery/ForecastLinkDao.kt
+++ b/app/src/main/java/com/example/volcanoseason3/data/gallery/ForecastLinkDao.kt
@@ -3,12 +3,18 @@ package com.example.volcanoseason3.data.gallery
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ForecastLinkDao {
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(link: ForecastLink)
 
     @Delete
     suspend fun delete(link: ForecastLink)
+
+    @Query("SELECT * FROM ForecastLink")
+    fun getAllLinks(): Flow<List<ForecastLink>>
 }

--- a/app/src/main/java/com/example/volcanoseason3/data/gallery/ForecastLinksRepository.kt
+++ b/app/src/main/java/com/example/volcanoseason3/data/gallery/ForecastLinksRepository.kt
@@ -1,0 +1,8 @@
+package com.example.volcanoseason3.data.gallery
+
+class ForecastLinksRepository(
+    private val dao: ForecastLinkDao
+) {
+    suspend fun insertForecastLink(link: ForecastLink) = dao.insert(link)
+    suspend fun deleteForecastLink(link: ForecastLink) = dao.delete(link)
+}

--- a/app/src/main/java/com/example/volcanoseason3/data/gallery/ForecastLinksRepository.kt
+++ b/app/src/main/java/com/example/volcanoseason3/data/gallery/ForecastLinksRepository.kt
@@ -5,4 +5,5 @@ class ForecastLinksRepository(
 ) {
     suspend fun insertForecastLink(link: ForecastLink) = dao.insert(link)
     suspend fun deleteForecastLink(link: ForecastLink) = dao.delete(link)
+    fun getAllForecastLinks() = dao.getAllLinks()
 }

--- a/app/src/main/java/com/example/volcanoseason3/data/gallery/MountainLink.kt
+++ b/app/src/main/java/com/example/volcanoseason3/data/gallery/MountainLink.kt
@@ -1,6 +1,10 @@
 package com.example.volcanoseason3.data.gallery
 
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity
 data class MountainLink(
-    val name: String,
+    @PrimaryKey val name: String,
     val link: String
 )

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinkAdapter.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinkAdapter.kt
@@ -1,22 +1,16 @@
 package com.example.volcanoseason3.ui.home
 
-import android.content.Context
-import android.content.Intent
-import android.net.Uri
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ArrayAdapter
 import android.widget.TextView
-import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.RecyclerView
 import com.example.volcanoseason3.R
 import com.example.volcanoseason3.data.gallery.ForecastLink
-import com.google.android.material.snackbar.Snackbar
 
 class ForecastLinkAdapter(
-    private val onClickPlaceHolder: (ForecastLink) -> Unit
+    private val onClick: (ForecastLink) -> Unit,
+    private val onLongClick: (ForecastLink) -> Boolean
 ) : RecyclerView.Adapter<ForecastLinkAdapter.ForecastLinkViewHolder>() {
     private var forecastLinks: MutableList<ForecastLink> = mutableListOf()
 
@@ -40,7 +34,7 @@ class ForecastLinkAdapter(
             LayoutInflater
                 .from(parent.context)
                 .inflate(R.layout.forecast_link_list_item, parent, false)
-        return ForecastLinkViewHolder(view, onClickPlaceHolder)
+        return ForecastLinkViewHolder(view, onClick, onLongClick)
     }
 
     override fun onBindViewHolder(
@@ -52,15 +46,20 @@ class ForecastLinkAdapter(
 
     class ForecastLinkViewHolder(
         view: View,
-        onClick: (ForecastLink) -> Unit
+        onClick: (ForecastLink) -> Unit,
+        onLongClick: (ForecastLink) -> Boolean
     ) : RecyclerView.ViewHolder(view) {
         private val forecastNameTV: TextView = view.findViewById(R.id.tv_forecast_name)
         private var currentForecast: ForecastLink? = null
 
         init {
             itemView.setOnClickListener {
-                Log.d("ForecastLinkAdapter", "IT: $it")
-                currentForecast?.let(onClick)
+                currentForecast?.let { onClick(it) }
+            }
+            itemView.setOnLongClickListener {
+                currentForecast?.let {
+                    onLongClick(it)
+                } ?: false // Return false if currentForecast is null
             }
         }
 

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinkAdapter.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinkAdapter.kt
@@ -8,13 +8,15 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import android.widget.TextView
+import androidx.fragment.app.viewModels
 import com.example.volcanoseason3.R
 import com.example.volcanoseason3.data.gallery.ForecastLink
 import com.google.android.material.snackbar.Snackbar
 
 class ForecastLinkAdapter(
     context: Context,
-    private val links: List<ForecastLink>
+    private val links: List<ForecastLink>,
+    private val viewModel: ForecastLinksViewModel
 ) : ArrayAdapter<ForecastLink>(context, 0, links) {
     override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
         var listItemView = convertView
@@ -63,6 +65,8 @@ class ForecastLinkAdapter(
                 listItemView,
                 "Remove ${currentLink.name}",
                 Snackbar.LENGTH_LONG).show()
+            viewModel.removeForecastLink(currentLink)
+//            viewModel.addForecastLink(currentLink)
             true
         }
 

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinkAdapter.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinkAdapter.kt
@@ -14,8 +14,8 @@ import com.google.android.material.snackbar.Snackbar
 
 class ForecastLinkAdapter(
     context: Context,
-    private val mountains: List<ForecastLink>
-) : ArrayAdapter<ForecastLink>(context, 0, mountains) {
+    private val links: List<ForecastLink>
+) : ArrayAdapter<ForecastLink>(context, 0, links) {
     override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
         var listItemView = convertView
 
@@ -28,18 +28,18 @@ class ForecastLinkAdapter(
             )
         }
 
-        val currentMountain = mountains[position]
+        val currentLink = links[position]
 
         // Set the name of the forecast mountain or region to the TextView
         val nameTextView: TextView = listItemView!!.findViewById(R.id.tv_mountain_name)
-        nameTextView.text = currentMountain.name
+        nameTextView.text = currentLink.name
 
         // Set the link of the forecast mountain or region to the click listener
         listItemView.setOnClickListener {
-            if (isValidUrl(currentMountain.url)) {
+            if (isValidUrl(currentLink.url)) {
                 try {
                     val intent = Intent(Intent.ACTION_VIEW)
-                    intent.setData(Uri.parse(currentMountain.url))
+                    intent.setData(Uri.parse(currentLink.url))
                     listItemView.context.startActivity(intent)
                 } catch (e: Exception) {
                     Snackbar.make(
@@ -51,7 +51,7 @@ class ForecastLinkAdapter(
             } else {
                 Snackbar.make(
                     listItemView,
-                    "Invalid URL. Cannot navigate to ${currentMountain.name} forecast.",
+                    "Invalid URL. Cannot navigate to ${currentLink.name} forecast.",
                     Snackbar.LENGTH_LONG
                 ).show()
             }
@@ -61,7 +61,7 @@ class ForecastLinkAdapter(
         listItemView.setOnLongClickListener {
             Snackbar.make(
                 listItemView,
-                "Remove ${currentMountain.name}",
+                "Remove ${currentLink.name}",
                 Snackbar.LENGTH_LONG).show()
             true
         }

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinkAdapter.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinkAdapter.kt
@@ -30,11 +30,11 @@ class ForecastLinkAdapter(
 
         val currentMountain = mountains[position]
 
-        // Set the name of the mountain to the TextView
+        // Set the name of the forecast mountain or region to the TextView
         val nameTextView: TextView = listItemView!!.findViewById(R.id.tv_mountain_name)
         nameTextView.text = currentMountain.name
 
-        // Set the link of the mountain to the click listener
+        // Set the link of the forecast mountain or region to the click listener
         listItemView.setOnClickListener {
             if (isValidUrl(currentMountain.url)) {
                 try {
@@ -56,6 +56,16 @@ class ForecastLinkAdapter(
                 ).show()
             }
         }
+
+        // Set a long-press listener for each ForecastLink item
+        listItemView.setOnLongClickListener {
+            Snackbar.make(
+                listItemView,
+                "Remove ${currentMountain.name}",
+                Snackbar.LENGTH_LONG).show()
+            true
+        }
+
         return listItemView
     }
 

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinkAdapter.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinkAdapter.kt
@@ -12,7 +12,7 @@ import com.example.volcanoseason3.R
 import com.example.volcanoseason3.data.gallery.ForecastLink
 import com.google.android.material.snackbar.Snackbar
 
-class MountainLinkAdapter(
+class ForecastLinkAdapter(
     context: Context,
     private val mountains: List<ForecastLink>
 ) : ArrayAdapter<ForecastLink>(context, 0, mountains) {

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinksViewModel.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinksViewModel.kt
@@ -2,6 +2,7 @@ package com.example.volcanoseason3.ui.home
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.example.volcanoseason3.data.gallery.AppDatabase
 import com.example.volcanoseason3.data.gallery.ForecastLink
@@ -12,6 +13,8 @@ class ForecastLinksViewModel(application: Application) : AndroidViewModel(applic
     private val repository = ForecastLinksRepository(
         AppDatabase.getInstance(application).forecastLinkDao()
     )
+
+    val forecastLinks = repository.getAllForecastLinks().asLiveData()
 
     fun addForecastLink(link: ForecastLink) {
         viewModelScope.launch {

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinksViewModel.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinksViewModel.kt
@@ -1,0 +1,27 @@
+package com.example.volcanoseason3.ui.home
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.volcanoseason3.data.gallery.AppDatabase
+import com.example.volcanoseason3.data.gallery.ForecastLink
+import com.example.volcanoseason3.data.gallery.ForecastLinksRepository
+import kotlinx.coroutines.launch
+
+class ForecastLinksViewModel(application: Application) : AndroidViewModel(application) {
+    private val repository = ForecastLinksRepository(
+        AppDatabase.getInstance(application).forecastLinkDao()
+    )
+
+    fun addForecastLink(link: ForecastLink) {
+        viewModelScope.launch {
+            repository.insertForecastLink(link)
+        }
+    }
+
+    fun removeForecastLink(link: ForecastLink) {
+        viewModelScope.launch {
+            repository.deleteForecastLink(link)
+        }
+    }
+}

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -19,7 +19,7 @@ class HomeFragment : Fragment() {
     private val binding get() = _binding!!
 
     private lateinit var forecastLinks: ArrayList<ForecastLink>
-    private lateinit var adapter: MountainLinkAdapter
+    private lateinit var adapter: ForecastLinkAdapter
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -36,7 +36,7 @@ class HomeFragment : Fragment() {
             linkNames.zip(links) { name, link -> ForecastLink(name, link) }.toList()
         )
 
-        adapter = MountainLinkAdapter(requireContext(), forecastLinks)
+        adapter = ForecastLinkAdapter(requireContext(), forecastLinks)
         binding.lvForecastList.adapter = adapter
 
         return root

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -1,5 +1,6 @@
 package com.example.volcanoseason3.ui.home
 
+import android.app.AlertDialog
 import android.database.sqlite.SQLiteConstraintException
 import android.os.Bundle
 import android.util.Log
@@ -71,8 +72,24 @@ class HomeFragment : Fragment() {
 
     private fun onForecastLinkLongPressed(link: ForecastLink): Boolean {
         Log.d("HomeFragment", "Long pressed on ForecastLink: $link")
-        viewModel.removeForecastLink(link)
+//        viewModel.removeForecastLink(link)
+        showConfirmationDialog(link)
         return true
+    }
+
+    private fun showConfirmationDialog(link: ForecastLink) {
+        val builder = AlertDialog.Builder(requireContext())
+        builder.setTitle("Remove Forecast Link")
+        builder.setMessage("Are you sure you want to remove\n${link.name}?")
+
+        builder.setPositiveButton("OK") { dialog, _ ->
+            viewModel.removeForecastLink(link)
+            dialog.dismiss()
+        }
+        builder.setNegativeButton("Cancel") { dialog, _ ->
+            dialog.dismiss()
+        }
+        builder.show()
     }
 
     private fun populateDefaultForecastLinks() {

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -1,7 +1,9 @@
 package com.example.volcanoseason3.ui.home
 
 import android.app.AlertDialog
+import android.content.Intent
 import android.database.sqlite.SQLiteConstraintException
+import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -68,11 +70,12 @@ class HomeFragment : Fragment() {
 
     private fun onForecastLinkClicked(link: ForecastLink) {
         Log.d("HomeFragment", "Clicked on ForecastLink: $link")
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(link.url))
+        startActivity(intent)
     }
 
     private fun onForecastLinkLongPressed(link: ForecastLink): Boolean {
         Log.d("HomeFragment", "Long pressed on ForecastLink: $link")
-//        viewModel.removeForecastLink(link)
         showConfirmationDialog(link)
         return true
     }

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -5,10 +5,9 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.textclassifier.TextLinks
 import androidx.fragment.app.Fragment
 import com.example.volcanoseason3.R
-import com.example.volcanoseason3.data.gallery.MountainLink
+import com.example.volcanoseason3.data.gallery.ForecastLink
 import com.example.volcanoseason3.databinding.FragmentHomeBinding
 
 class HomeFragment : Fragment() {
@@ -19,7 +18,7 @@ class HomeFragment : Fragment() {
     // onDestroyView.
     private val binding get() = _binding!!
 
-    private lateinit var mountainLinks: ArrayList<MountainLink>
+    private lateinit var forecastLinks: ArrayList<ForecastLink>
     private lateinit var adapter: MountainLinkAdapter
 
     override fun onCreateView(
@@ -33,21 +32,21 @@ class HomeFragment : Fragment() {
         val linkNames : Array<String> = resources.getStringArray(R.array.forecast_link_names)
         val links : Array<String> = resources.getStringArray(R.array.forecast_links)
 
-        mountainLinks = ArrayList(
-            linkNames.zip(links) { name, link -> MountainLink(name, link) }.toList()
+        forecastLinks = ArrayList(
+            linkNames.zip(links) { name, link -> ForecastLink(name, link) }.toList()
         )
 
-        adapter = MountainLinkAdapter(requireContext(), mountainLinks)
+        adapter = MountainLinkAdapter(requireContext(), forecastLinks)
         binding.lvForecastList.adapter = adapter
 
         return root
     }
 
     fun addLink(name: String, link: String) {
-        Log.d("HomeFragment", "Adding link for mountain: $name, $link")
-        val newMountainLink = MountainLink(name, link)
+        Log.d("HomeFragment", "Adding link for forecast: $name, $link")
+        val newForecastLink = ForecastLink(name, link)
         // Temporary organization adds the new link to the 2nd to last index
-        mountainLinks.add(mountainLinks.size - 1, newMountainLink)
+        forecastLinks.add(forecastLinks.size - 1, newForecastLink)
         adapter.notifyDataSetChanged()
     }
 

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -46,7 +46,7 @@ class HomeFragment : Fragment() {
         forecastLinks.layoutManager = LinearLayoutManager(requireContext())
         forecastLinks.setHasFixedSize(true)
 
-        adapter = ForecastLinkAdapter(::onForecastLinkClicked)
+        adapter = ForecastLinkAdapter(::onForecastLinkClicked, ::onForecastLinkLongPressed)
         forecastLinks.adapter = adapter
 
         populateDefaultForecastLinks()
@@ -56,29 +56,6 @@ class HomeFragment : Fragment() {
             adapter.updateForecastLinks(links.toMutableList())
             forecastLinks.scrollToPosition(0)
         }
-
-        val itemTouchCallback =
-            object : ItemTouchHelper.SimpleCallback(
-                0,
-                ItemTouchHelper.LEFT
-            ) {
-                override fun onMove(
-                    recyclerView: RecyclerView,
-                    viewHolder: RecyclerView.ViewHolder,
-                    target: RecyclerView.ViewHolder
-                ): Boolean {
-                    return false
-                }
-
-                override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
-                    Log.d("HomeFragment", "Swiped $direction")
-                    val forecastLink = adapter.getItemAt(viewHolder.adapterPosition)
-
-                    viewModel.removeForecastLink(forecastLink)
-                }
-            }
-
-        ItemTouchHelper(itemTouchCallback).attachToRecyclerView(forecastLinks)
     }
 
     fun addLink(name: String, link: String) {
@@ -90,6 +67,12 @@ class HomeFragment : Fragment() {
 
     private fun onForecastLinkClicked(link: ForecastLink) {
         Log.d("HomeFragment", "Clicked on ForecastLink: $link")
+    }
+
+    private fun onForecastLinkLongPressed(link: ForecastLink): Boolean {
+        Log.d("HomeFragment", "Long pressed on ForecastLink: $link")
+        viewModel.removeForecastLink(link)
+        return true
     }
 
     private fun populateDefaultForecastLinks() {

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import com.example.volcanoseason3.R
 import com.example.volcanoseason3.data.gallery.ForecastLink
 import com.example.volcanoseason3.databinding.FragmentHomeBinding
@@ -17,6 +18,8 @@ class HomeFragment : Fragment() {
     // This property is only valid between onCreateView and
     // onDestroyView.
     private val binding get() = _binding!!
+
+    private val viewModel: ForecastLinksViewModel by viewModels()
 
     private lateinit var forecastLinks: ArrayList<ForecastLink>
     private lateinit var adapter: ForecastLinkAdapter
@@ -36,7 +39,7 @@ class HomeFragment : Fragment() {
             linkNames.zip(links) { name, link -> ForecastLink(name, link) }.toList()
         )
 
-        adapter = ForecastLinkAdapter(requireContext(), forecastLinks)
+        adapter = ForecastLinkAdapter(requireContext(), forecastLinks, viewModel)
         binding.lvForecastList.adapter = adapter
 
         return root
@@ -47,6 +50,7 @@ class HomeFragment : Fragment() {
         val newForecastLink = ForecastLink(name, link)
         // Temporary organization adds the new link to the 2nd to last index
         forecastLinks.add(forecastLinks.size - 1, newForecastLink)
+        viewModel.addForecastLink(newForecastLink)
         adapter.notifyDataSetChanged()
     }
 

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/MountainLinkAdapter.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/MountainLinkAdapter.kt
@@ -9,13 +9,13 @@ import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import android.widget.TextView
 import com.example.volcanoseason3.R
-import com.example.volcanoseason3.data.gallery.MountainLink
+import com.example.volcanoseason3.data.gallery.ForecastLink
 import com.google.android.material.snackbar.Snackbar
 
 class MountainLinkAdapter(
     context: Context,
-    private val mountains: List<MountainLink>
-) : ArrayAdapter<MountainLink>(context, 0, mountains) {
+    private val mountains: List<ForecastLink>
+) : ArrayAdapter<ForecastLink>(context, 0, mountains) {
     override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
         var listItemView = convertView
 
@@ -36,10 +36,10 @@ class MountainLinkAdapter(
 
         // Set the link of the mountain to the click listener
         listItemView.setOnClickListener {
-            if (isValidUrl(currentMountain.link)) {
+            if (isValidUrl(currentMountain.url)) {
                 try {
                     val intent = Intent(Intent.ACTION_VIEW)
-                    intent.setData(Uri.parse(currentMountain.link))
+                    intent.setData(Uri.parse(currentMountain.url))
                     listItemView.context.startActivity(intent)
                 } catch (e: Exception) {
                     Snackbar.make(

--- a/app/src/main/res/layout/forecast_link_list_item.xml
+++ b/app/src/main/res/layout/forecast_link_list_item.xml
@@ -10,7 +10,7 @@
     app:cardBackgroundColor="@color/medium_blue">
 
     <TextView
-        android:id="@+id/tv_mountain_name"
+        android:id="@+id/tv_forecast_name"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -5,8 +5,8 @@
     android:layout_height="match_parent"
     tools:context=".ui.home.HomeFragment">
 
-    <ListView
-        android:id="@+id/lv_forecast_list"
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_forecast_list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:divider="@android:color/transparent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,8 +65,9 @@
         <item>https://forecast.weather.gov/MapClick.php?lat=44.06&amp;lon=-121.3#.YsZ5b-zMLeo</item>
     </string-array>
 
-    <string name="dialog_name">Mountain Name</string>
-    <string name="dialog_link">Forecast Link</string>
+    <string name="dialog_title">Add a forecast</string>
+    <string name="dialog_name">Forecast Name</string>
+    <string name="dialog_link">Link URL</string>
     <string name="dialog_radio_volcano">&volcano; Volcano</string>
     <string name="dialog_radio_region">&sun_clouds; Region</string>
 


### PR DESCRIPTION
## What's new?
- Added local storage persistence using the Room library
- Renamed the `MountainLink` class to `ForecastLink` to include regions such as Bend NOAA
- Converted the `ListView` of the `ForecastLink` objects to `RecyclerView` for better integration with data storage 
- Added a long-press delete option. Trialed swipe to delete with `RecyclerView` but returned to long-press. 
- Added dialog to confirm `ForecastLink` removal after long-press with OK and Cancel as options

Closes #5 
Closes #13 
Closes #16 

## What's next?
- Tweak layout of Material Cards. Padding appears to be enlarged after conversion to `RecyclerView`
- Split volcanoes and regions and organize each alphabetically