### PR TITLE
Add edit forecast link details

### DIFF
--- a/app/schemas/com.example.volcanoseason3.data.gallery.AppDatabase/3.json
+++ b/app/schemas/com.example.volcanoseason3.data.gallery.AppDatabase/3.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 2,
+    "version": 3,
     "identityHash": "57263546802c04905423476f0c81d083",
     "entities": [
       {

--- a/app/src/main/java/com/example/volcanoseason3/data/gallery/AppDatabase.kt
+++ b/app/src/main/java/com/example/volcanoseason3/data/gallery/AppDatabase.kt
@@ -5,15 +5,14 @@ import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 const val DATABASE_NAME = "forecast-links-db"
 
 @Database(
     entities = [ForecastLink::class],
-    version = 2,
-    autoMigrations = [
-        AutoMigration(from = 1, to = 2)
-    ]
+    version = 3
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun forecastLinkDao() : ForecastLinkDao
@@ -26,13 +25,43 @@ abstract class AppDatabase : RoomDatabase() {
                 context,
                 AppDatabase::class.java,
                 DATABASE_NAME
-            ).build()
+            )
+                .addMigrations(MIGRATION_2_3)
+                .build()
 
         fun getInstance(context: Context) : AppDatabase {
             return  instance ?: synchronized(this) {
                 instance ?: buildDatabase(context).also {
                     instance = it
                 }
+            }
+        }
+
+        // Manual Migration to version 3
+        val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // Create a new table with the new schema
+                db.execSQL(
+                    """
+                    CREATE TABLE new_ForecastLink (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        name TEXT NOT NULL,
+                        url TEXT NOT NULL,
+                        emoji TEXT NOT NULL DEFAULT '🌋'
+                    )
+                    """.trimIndent()
+                )
+                // Copy the data from the old table to the new table
+                db.execSQL(
+                    """
+                    INSERT INTO new_ForecastLink (name, url, emoji)
+                    SELECT name, url, emoji FROM ForecastLink
+                    """.trimIndent()
+                )
+                // Remove the old table
+                db.execSQL("DROP TABLE ForecastLink")
+                // Rename the new table to the old table name
+                db.execSQL("ALTER TABLE new_ForecastLink RENAME TO ForecastLink")
             }
         }
     }

--- a/app/src/main/java/com/example/volcanoseason3/data/gallery/ForecastLink.kt
+++ b/app/src/main/java/com/example/volcanoseason3/data/gallery/ForecastLink.kt
@@ -6,7 +6,9 @@ import androidx.room.PrimaryKey
 
 @Entity
 data class ForecastLink(
-    @PrimaryKey val name: String,
+    @PrimaryKey(autoGenerate = true)
+    val id: Int = 0,
+    val name: String,
     val url: String,
     @ColumnInfo(name = "emoji", defaultValue = "\uD83C\uDF0B")
     val emoji: String = "\uD83C\uDF0B"

--- a/app/src/main/java/com/example/volcanoseason3/data/gallery/ForecastLinkDao.kt
+++ b/app/src/main/java/com/example/volcanoseason3/data/gallery/ForecastLinkDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -14,6 +15,9 @@ interface ForecastLinkDao {
 
     @Delete
     suspend fun delete(link: ForecastLink)
+
+    @Update
+    suspend fun update(link: ForecastLink)
 
     @Query("SELECT * FROM ForecastLink")
     fun getAllLinks(): Flow<List<ForecastLink>>

--- a/app/src/main/java/com/example/volcanoseason3/data/gallery/ForecastLinksRepository.kt
+++ b/app/src/main/java/com/example/volcanoseason3/data/gallery/ForecastLinksRepository.kt
@@ -5,5 +5,6 @@ class ForecastLinksRepository(
 ) {
     suspend fun insertForecastLink(link: ForecastLink) = dao.insert(link)
     suspend fun deleteForecastLink(link: ForecastLink) = dao.delete(link)
+    suspend fun updateForecastLink(link: ForecastLink) = dao.update(link)
     fun getAllForecastLinks() = dao.getAllLinks()
 }

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinksViewModel.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinksViewModel.kt
@@ -7,7 +7,9 @@ import androidx.lifecycle.viewModelScope
 import com.example.volcanoseason3.data.gallery.AppDatabase
 import com.example.volcanoseason3.data.gallery.ForecastLink
 import com.example.volcanoseason3.data.gallery.ForecastLinksRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class ForecastLinksViewModel(application: Application) : AndroidViewModel(application) {
     private val repository = ForecastLinksRepository(
@@ -25,6 +27,12 @@ class ForecastLinksViewModel(application: Application) : AndroidViewModel(applic
     fun removeForecastLink(link: ForecastLink) {
         viewModelScope.launch {
             repository.deleteForecastLink(link)
+        }
+    }
+
+    fun updateForecastLink(link: ForecastLink) {
+        viewModelScope.launch {
+            repository.updateForecastLink(link)
         }
     }
 }

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -137,7 +137,7 @@ class HomeFragment : Fragment() {
     private fun showRemoveLinkConfirmationDialog(link: ForecastLink, position: Int) {
         val builder = AlertDialog.Builder(requireContext())
         builder.setTitle("Remove Forecast Link")
-        builder.setMessage("Are you sure you want to remove\n${link.name}?")
+        builder.setMessage("Are you sure you want to remove\n${link.emoji} ${link.name}?")
 
         builder.setPositiveButton("OK") { dialog, _ ->
             viewModel.removeForecastLink(link)

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -156,7 +156,7 @@ class HomeFragment : Fragment() {
         }
 
         androidx.appcompat.app.AlertDialog.Builder(requireContext())
-            .setTitle("Edit Forecast Link ${link.name}")    // Maybe put this in strings.xml
+            .setTitle("Edit Forecast Link")    // Maybe put this in strings.xml
             .setView(dialogView)
             .setPositiveButton("Update") { dialog, _ ->
                 val updatedName = editTextName.text.toString()

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -134,7 +134,6 @@ class HomeFragment : Fragment() {
 
     private fun onForecastLinkLongPressed(link: ForecastLink): Boolean {
         Log.d("HomeFragment", "Long pressed on ForecastLink: $link")
-        Snackbar.make(binding.root, "Add the edit ForecastLink option here", Snackbar.LENGTH_LONG).show()
         showEditLinkDialog(link)
         return true
     }

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -121,7 +121,7 @@ class HomeFragment : Fragment() {
 
     fun addLink(name: String, link: String, emoji: String) {
         Log.d("HomeFragment", "Adding link for forecast: $name, $link")
-        val newForecastLink = ForecastLink(name, link, emoji)
+        val newForecastLink = ForecastLink(name = name, url = link, emoji = emoji)
         viewModel.addForecastLink(newForecastLink)
         adapter.notifyDataSetChanged()
     }
@@ -208,9 +208,9 @@ class HomeFragment : Fragment() {
         val defaultForecastLinks = ArrayList(
             linkNames.zip(links) { name, link ->
                 if (name.contains("NOAA")) {
-                    ForecastLink(name, link, regionEmoji)
+                    ForecastLink(name = name, url = link, emoji = regionEmoji)
                 } else {
-                    ForecastLink(name, link, volcanoEmoji)
+                    ForecastLink(name = name, url = link, emoji = volcanoEmoji)
                 }
             }.toList()
         )

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -166,12 +166,6 @@ class HomeFragment : Fragment() {
                     R.id.radio_button_region -> getString(R.string.emoji_region)
                     else -> link.emoji
                 }
-//                if (isValidUrl(updatedUrl)) {
-//                    addLinkToHomeFragment(updatedName, updatedUrl, updatedEmoji)
-//                } else {
-//                    Snackbar.make(binding.root, "Invalid URL. Please try again", Snackbar.LENGTH_LONG).show()
-//                }
-
                 val updatedLink = link.copy(name = updatedName, url = updatedUrl, emoji = updatedEmoji)
                 viewModel.updateForecastLink(updatedLink)
                 adapter.notifyDataSetChanged()


### PR DESCRIPTION
## What's new?
- Re-implemented remove on swipe, but integrated the confirmation dialog when a ForecastLink item is swiped
- Added dialog window with edit fields to appear on long press of ForecastLink object
- Added autogenerated id field to ForecastLink Entity to use as primary key and migrated Room database to version 3. This allows the ForecastLink name to be edited by the user. 

Closes #25 