### PR TITLE
Customize forecast list

### DIFF
--- a/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinkAdapter.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinkAdapter.kt
@@ -3,21 +3,43 @@ package com.example.volcanoseason3.ui.home
 import android.content.ActivityNotFoundException
 import android.util.Log
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
 import com.example.volcanoseason3.R
 import com.example.volcanoseason3.data.gallery.ForecastLink
 import com.google.android.material.snackbar.Snackbar
+import java.util.Collections
 
 class ForecastLinkAdapter(
     private val onClick: (ForecastLink) -> Unit,
     private val onLongClick: (ForecastLink) -> Boolean,
     private var dragDropEnabled: Boolean = false
 ) : RecyclerView.Adapter<ForecastLinkAdapter.ForecastLinkViewHolder>() {
+
     private var forecastLinks: MutableList<ForecastLink> = mutableListOf()
+    private lateinit var itemTouchHelper: ItemTouchHelper
+
+    fun setItemTouchHelper(itemTouchHelper: ItemTouchHelper) {
+        this.itemTouchHelper = itemTouchHelper
+    }
+
+    fun moveItem(fromPosition: Int, toPosition: Int) {
+        if (fromPosition < toPosition) {
+            for (i in fromPosition until toPosition) {
+                Collections.swap(forecastLinks, i, i + 1)
+            }
+        } else {
+            for (i in fromPosition downTo toPosition + 1) {
+                Collections.swap(forecastLinks, i, i - 1)
+            }
+        }
+        notifyItemMoved(fromPosition, toPosition)
+    }
 
     fun getItemAt(position: Int): ForecastLink {
         return forecastLinks[position]
@@ -39,7 +61,7 @@ class ForecastLinkAdapter(
             LayoutInflater
                 .from(parent.context)
                 .inflate(R.layout.forecast_link_list_item, parent, false)
-        return ForecastLinkViewHolder(view, onClick, onLongClick)
+        return ForecastLinkViewHolder(view, onClick, onLongClick, dragDropEnabled, itemTouchHelper)
     }
 
     override fun onBindViewHolder(
@@ -57,7 +79,9 @@ class ForecastLinkAdapter(
     class ForecastLinkViewHolder(
         view: View,
         onClick: (ForecastLink) -> Unit,
-        onLongClick: (ForecastLink) -> Boolean
+        onLongClick: (ForecastLink) -> Boolean,
+        private val dragDropEnabled: Boolean,
+        private val itemTouchHelper: ItemTouchHelper
     ) : RecyclerView.ViewHolder(view) {
         private val forecastNameTV: TextView = view.findViewById(R.id.tv_forecast_name)
         private val dragIndicatorIV: ImageView = view.findViewById(R.id.iv_drag_indicator)
@@ -82,10 +106,18 @@ class ForecastLinkAdapter(
                     }
                 }
             }
+
             itemView.setOnLongClickListener {
                 currentForecast?.let {
                     onLongClick(it)
                 } ?: false // Return false if currentForecast is null
+            }
+
+            dragIndicatorIV.setOnTouchListener {_, event ->
+                if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+                    itemTouchHelper.startDrag(this)
+                }
+                false
             }
         }
 

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinkAdapter.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinkAdapter.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.example.volcanoseason3.R
@@ -13,7 +14,8 @@ import com.google.android.material.snackbar.Snackbar
 
 class ForecastLinkAdapter(
     private val onClick: (ForecastLink) -> Unit,
-    private val onLongClick: (ForecastLink) -> Boolean
+    private val onLongClick: (ForecastLink) -> Boolean,
+    private var dragDropEnabled: Boolean = false
 ) : RecyclerView.Adapter<ForecastLinkAdapter.ForecastLinkViewHolder>() {
     private var forecastLinks: MutableList<ForecastLink> = mutableListOf()
 
@@ -44,7 +46,12 @@ class ForecastLinkAdapter(
         holder: ForecastLinkViewHolder,
         position: Int
     ) {
-        holder.bind(forecastLinks[position])
+        holder.bind(forecastLinks[position], dragDropEnabled)
+    }
+
+    fun updateDragDropEnabled(enabled: Boolean) {
+        dragDropEnabled = enabled
+        notifyDataSetChanged()
     }
 
     class ForecastLinkViewHolder(
@@ -53,6 +60,7 @@ class ForecastLinkAdapter(
         onLongClick: (ForecastLink) -> Boolean
     ) : RecyclerView.ViewHolder(view) {
         private val forecastNameTV: TextView = view.findViewById(R.id.tv_forecast_name)
+        private val dragIndicatorIV: ImageView = view.findViewById(R.id.iv_drag_indicator)
         private var currentForecast: ForecastLink? = null
 
         init {
@@ -81,10 +89,11 @@ class ForecastLinkAdapter(
             }
         }
 
-        fun bind(forecastlink: ForecastLink) {
+        fun bind(forecastlink: ForecastLink, dragDropEnabled: Boolean) {
             val concatenatedName = "${forecastlink.emoji}  ${forecastlink.name}"
             currentForecast = forecastlink
             forecastNameTV.text = concatenatedName
+            dragIndicatorIV.visibility = if (dragDropEnabled) View.VISIBLE else View.GONE
         }
 
         private fun isValidUrl(url: String): Boolean {

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinkAdapter.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/ForecastLinkAdapter.kt
@@ -1,6 +1,7 @@
 package com.example.volcanoseason3.ui.home
 
 import android.content.ActivityNotFoundException
+import android.content.SharedPreferences
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.MotionEvent
@@ -23,9 +24,14 @@ class ForecastLinkAdapter(
 
     private var forecastLinks: MutableList<ForecastLink> = mutableListOf()
     private lateinit var itemTouchHelper: ItemTouchHelper
+    private lateinit var sharedPreferences: SharedPreferences
 
     fun setItemTouchHelper(itemTouchHelper: ItemTouchHelper) {
         this.itemTouchHelper = itemTouchHelper
+    }
+
+    fun setSharedPreferences(sharedPreferences: SharedPreferences) {
+        this.sharedPreferences = sharedPreferences
     }
 
     fun moveItem(fromPosition: Int, toPosition: Int) {
@@ -38,11 +44,32 @@ class ForecastLinkAdapter(
                 Collections.swap(forecastLinks, i, i - 1)
             }
         }
+        saveOrderToPreferences()
         notifyItemMoved(fromPosition, toPosition)
+    }
+
+    fun saveOrderToPreferences() {
+        Log.d("ForecastLinkAdapter", "saveOrderToPreferences called")
+        val editor = sharedPreferences.edit()
+        val order = forecastLinks.map { it.id }
+        editor.putString("forecast_order", order.joinToString(","))
+        editor.apply()
+    }
+
+    fun loadOrderFromPreferences() {
+        val orderString = sharedPreferences.getString("forecast_order", null)
+        orderString?.let {
+            val order = it.split(",").map { it.toInt() }
+            forecastLinks.sortBy { forecastLink -> order.indexOf(forecastLink.id) }
+        }
     }
 
     fun getItemAt(position: Int): ForecastLink {
         return forecastLinks[position]
+    }
+
+    fun getForecastLinks(): List<ForecastLink> {
+        return forecastLinks.toList()
     }
 
     fun updateForecastLinks(updatedLinks: MutableList<ForecastLink>) {
@@ -72,6 +99,7 @@ class ForecastLinkAdapter(
     }
 
     fun updateDragDropEnabled(enabled: Boolean) {
+        Log.d("ForecastLinkAdapter", "updateDragDropEnabled called with enabled: $enabled")
         dragDropEnabled = enabled
         notifyDataSetChanged()
     }

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -16,6 +16,8 @@ import android.widget.EditText
 import android.widget.RadioButton
 import android.widget.RadioGroup
 import android.widget.Spinner
+import android.widget.Switch
+import androidx.appcompat.widget.SwitchCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -217,13 +219,27 @@ class HomeFragment : Fragment() {
         val spinnerSortBy = dialogView.findViewById<Spinner>(R.id.spinner_sort_by)
         val spinnerSeparation = dialogView.findViewById<Spinner>(R.id.spinner_separation)
 //        val spinnerCustomOptions = dialogView.findViewById<Spinner>(R.id.spinner_custom)
+        val switchDragDrop = dialogView.findViewById<SwitchCompat>(R.id.switch_drag_n_drop)
 
         val sharedPreferences = requireContext().getSharedPreferences("HomeFragmentSettings", Context.MODE_PRIVATE)
 
         // Load previously saved settings
         val savedSortBy = sharedPreferences.getString("sortBy", getString(R.string.pref_sort_val_alphabet))
         val savedSeparation = sharedPreferences.getString("separation", getString(R.string.prefs_separate_val_volcano))
-        val savedCustom = sharedPreferences.getString("custom", getString(R.string.pref_custom_val_1))
+//        val savedCustom = sharedPreferences.getString("custom", getString(R.string.pref_custom_val_1))
+        val savedDragDrop = sharedPreferences.getString("dragDrop", "disabled")
+
+        // Set the state of the switch based on saved value
+        val isDragDropEnabled = savedDragDrop == "enabled"
+        switchDragDrop.isChecked = isDragDropEnabled
+        spinnerSortBy.isEnabled = !isDragDropEnabled
+        spinnerSeparation.isEnabled = !isDragDropEnabled
+
+        // Set an OnCheckedChangeListener for the Switch
+        switchDragDrop.setOnCheckedChangeListener { _, isChecked ->
+            spinnerSortBy.isEnabled = !isChecked
+            spinnerSeparation.isEnabled = !isChecked
+        }
 
         // Map saved values to entries and set them as selected values in spinners
         setSpinnerSelection(spinnerSortBy, savedSortBy, R.array.options_sort_by_entries, R.array.options_sort_by_values)
@@ -237,12 +253,14 @@ class HomeFragment : Fragment() {
                 val sortBy = getSpinnerValue(spinnerSortBy, R.array.options_sort_by_values)
                 val separation = getSpinnerValue(spinnerSeparation, R.array.options_separation_values)
 //                val custom = getSpinnerValue(spinnerCustomOptions, R.array.options_custom_values)
+                val dragDropState = if (switchDragDrop.isChecked) "enabled" else "disabled"
 
                 // Save the selected settings to SharedPreferences
                 with(sharedPreferences.edit()) {
                     putString("sortBy", sortBy)
                     putString("separation", separation)
 //                    putString("custom", custom)
+                    putString("dragDrop", dragDropState)
                     apply()
                 }
 

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -91,16 +91,29 @@ class HomeFragment : Fragment() {
         adapter = ForecastLinkAdapter(::onForecastLinkClicked, ::onForecastLinkLongPressed)
         forecastLinks.adapter = adapter
 
-        val itemTouchHelperCallback = object : ItemTouchHelper.SimpleCallback(
-            0,
-            ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT
-        ) {
+//        val itemTouchHelperCallback = object : ItemTouchHelper.SimpleCallback(
+//            0,
+//            ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT
+//        ) {
+        val itemTouchHelperCallback = object : ItemTouchHelper.Callback() {
+
+            override fun getMovementFlags(
+                recyclerView: RecyclerView,
+                viewHolder: RecyclerView.ViewHolder
+            ): Int {
+                val dragFlags = ItemTouchHelper.UP or ItemTouchHelper.DOWN
+                val swipeFlags = ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT
+                return makeMovementFlags(dragFlags, swipeFlags)
+            }
+
             override fun onMove(
                 recyclerView: RecyclerView,
                 viewHolder: RecyclerView.ViewHolder,
                 target: RecyclerView.ViewHolder
             ): Boolean {
-                return false
+//                return false
+                adapter.moveItem(viewHolder.adapterPosition, target.adapterPosition)
+                return true
             }
 
             override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
@@ -108,9 +121,18 @@ class HomeFragment : Fragment() {
                 val forecastLink = adapter.getItemAt(position)
                 showRemoveLinkConfirmationDialog(forecastLink, position)
             }
+
+            override fun isLongPressDragEnabled(): Boolean {
+                return false // False so drag is only enabled from the drag handle.
+            }
+
+            override fun isItemViewSwipeEnabled(): Boolean {
+                return true
+            }
         }
 
         val itemTouchHelper = ItemTouchHelper(itemTouchHelperCallback)
+        adapter.setItemTouchHelper(itemTouchHelper)
         itemTouchHelper.attachToRecyclerView(forecastLinks)
 
         viewModel.forecastLinks.observe(viewLifecycleOwner) { links ->

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -94,10 +94,6 @@ class HomeFragment : Fragment() {
         val sharedPreferences = requireContext().getSharedPreferences("HomeFragmentSettings", Context.MODE_PRIVATE)
         adapter.setSharedPreferences(sharedPreferences)
 
-//        val itemTouchHelperCallback = object : ItemTouchHelper.SimpleCallback(
-//            0,
-//            ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT
-//        ) {
         val itemTouchHelperCallback = object : ItemTouchHelper.Callback() {
 
             override fun getMovementFlags(
@@ -114,7 +110,6 @@ class HomeFragment : Fragment() {
                 viewHolder: RecyclerView.ViewHolder,
                 target: RecyclerView.ViewHolder
             ): Boolean {
-//                return false
                 adapter.moveItem(viewHolder.adapterPosition, target.adapterPosition)
                 return true
             }
@@ -139,9 +134,6 @@ class HomeFragment : Fragment() {
         itemTouchHelper.attachToRecyclerView(forecastLinks)
 
         viewModel.forecastLinks.observe(viewLifecycleOwner) { links ->
-//            val sortedLinks = separateLinks(sortLinks(links.toMutableList()))
-//            adapter.updateForecastLinks(sortedLinks)
-//            forecastLinks.scrollToPosition(0)
             applySortingAndUpdate(links.toMutableList())
         }
     }
@@ -304,9 +296,6 @@ class HomeFragment : Fragment() {
 
                 // Apply the new sorting
                 val links = viewModel.forecastLinks.value ?: emptyList()
-//                val sortedLinks = separateLinks(sortLinks(links.toMutableList()))
-//                adapter.updateForecastLinks(sortedLinks)
-//                adapter.updateDragDropEnabled(isDragDropEnabled)
                 applySortingAndUpdate(links.toMutableList())
 
                 dialog.dismiss()

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -216,7 +216,7 @@ class HomeFragment : Fragment() {
         val dialogView = LayoutInflater.from(requireContext()).inflate(R.layout.dialog_organize_links, null)
         val spinnerSortBy = dialogView.findViewById<Spinner>(R.id.spinner_sort_by)
         val spinnerSeparation = dialogView.findViewById<Spinner>(R.id.spinner_separation)
-        val spinnerCustomOptions = dialogView.findViewById<Spinner>(R.id.spinner_custom)
+//        val spinnerCustomOptions = dialogView.findViewById<Spinner>(R.id.spinner_custom)
 
         val sharedPreferences = requireContext().getSharedPreferences("HomeFragmentSettings", Context.MODE_PRIVATE)
 
@@ -228,7 +228,7 @@ class HomeFragment : Fragment() {
         // Map saved values to entries and set them as selected values in spinners
         setSpinnerSelection(spinnerSortBy, savedSortBy, R.array.options_sort_by_entries, R.array.options_sort_by_values)
         setSpinnerSelection(spinnerSeparation, savedSeparation, R.array.options_separation_entries, R.array.options_separation_values)
-        setSpinnerSelection(spinnerCustomOptions, savedCustom, R.array.options_custom_entries, R.array.options_custom_values)
+//        setSpinnerSelection(spinnerCustomOptions, savedCustom, R.array.options_custom_entries, R.array.options_custom_values)
 
         androidx.appcompat.app.AlertDialog.Builder(requireContext())
             .setTitle("Organize Forecast Links")
@@ -236,13 +236,13 @@ class HomeFragment : Fragment() {
             .setPositiveButton("OK") { dialog, _ ->
                 val sortBy = getSpinnerValue(spinnerSortBy, R.array.options_sort_by_values)
                 val separation = getSpinnerValue(spinnerSeparation, R.array.options_separation_values)
-                val custom = getSpinnerValue(spinnerCustomOptions, R.array.options_custom_values)
+//                val custom = getSpinnerValue(spinnerCustomOptions, R.array.options_custom_values)
 
                 // Save the selected settings to SharedPreferences
                 with(sharedPreferences.edit()) {
                     putString("sortBy", sortBy)
                     putString("separation", separation)
-                    putString("custom", custom)
+//                    putString("custom", custom)
                     apply()
                 }
 

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -230,7 +230,7 @@ class HomeFragment : Fragment() {
         val savedDragDrop = sharedPreferences.getString("dragDrop", "disabled")
 
         // Set the state of the switch based on saved value
-        val isDragDropEnabled = savedDragDrop == "enabled"
+        var isDragDropEnabled = savedDragDrop == "enabled"
         switchDragDrop.isChecked = isDragDropEnabled
         spinnerSortBy.isEnabled = !isDragDropEnabled
         spinnerSeparation.isEnabled = !isDragDropEnabled
@@ -239,6 +239,9 @@ class HomeFragment : Fragment() {
         switchDragDrop.setOnCheckedChangeListener { _, isChecked ->
             spinnerSortBy.isEnabled = !isChecked
             spinnerSeparation.isEnabled = !isChecked
+
+            // Update the temporary Drag Drop variable
+            isDragDropEnabled = isChecked
         }
 
         // Map saved values to entries and set them as selected values in spinners
@@ -253,7 +256,7 @@ class HomeFragment : Fragment() {
                 val sortBy = getSpinnerValue(spinnerSortBy, R.array.options_sort_by_values)
                 val separation = getSpinnerValue(spinnerSeparation, R.array.options_separation_values)
 //                val custom = getSpinnerValue(spinnerCustomOptions, R.array.options_custom_values)
-                val dragDropState = if (switchDragDrop.isChecked) "enabled" else "disabled"
+                val dragDropState = if (isDragDropEnabled) "enabled" else "disabled"
 
                 // Save the selected settings to SharedPreferences
                 with(sharedPreferences.edit()) {
@@ -268,6 +271,7 @@ class HomeFragment : Fragment() {
                 val links = viewModel.forecastLinks.value ?: emptyList()
                 val sortedLinks = separateLinks(sortLinks(links.toMutableList()))
                 adapter.updateForecastLinks(sortedLinks)
+                adapter.updateDragDropEnabled(isDragDropEnabled)
 
                 dialog.dismiss()
             }

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -34,8 +34,7 @@ class HomeFragment : Fragment() {
 
     private var _binding: FragmentHomeBinding? = null
 
-    // This property is only valid between onCreateView and
-    // onDestroyView.
+    // This property is only valid between onCreateView and onDestroyView.
     private val binding get() = _binding!!
 
     private val viewModel: ForecastLinksViewModel by viewModels()
@@ -218,7 +217,6 @@ class HomeFragment : Fragment() {
         val dialogView = LayoutInflater.from(requireContext()).inflate(R.layout.dialog_organize_links, null)
         val spinnerSortBy = dialogView.findViewById<Spinner>(R.id.spinner_sort_by)
         val spinnerSeparation = dialogView.findViewById<Spinner>(R.id.spinner_separation)
-//        val spinnerCustomOptions = dialogView.findViewById<Spinner>(R.id.spinner_custom)
         val switchDragDrop = dialogView.findViewById<SwitchCompat>(R.id.switch_drag_n_drop)
 
         val sharedPreferences = requireContext().getSharedPreferences("HomeFragmentSettings", Context.MODE_PRIVATE)
@@ -226,7 +224,6 @@ class HomeFragment : Fragment() {
         // Load previously saved settings
         val savedSortBy = sharedPreferences.getString("sortBy", getString(R.string.pref_sort_val_alphabet))
         val savedSeparation = sharedPreferences.getString("separation", getString(R.string.prefs_separate_val_volcano))
-//        val savedCustom = sharedPreferences.getString("custom", getString(R.string.pref_custom_val_1))
         val savedDragDrop = sharedPreferences.getString("dragDrop", "disabled")
 
         // Set the state of the switch based on saved value
@@ -247,7 +244,6 @@ class HomeFragment : Fragment() {
         // Map saved values to entries and set them as selected values in spinners
         setSpinnerSelection(spinnerSortBy, savedSortBy, R.array.options_sort_by_entries, R.array.options_sort_by_values)
         setSpinnerSelection(spinnerSeparation, savedSeparation, R.array.options_separation_entries, R.array.options_separation_values)
-//        setSpinnerSelection(spinnerCustomOptions, savedCustom, R.array.options_custom_entries, R.array.options_custom_values)
 
         androidx.appcompat.app.AlertDialog.Builder(requireContext())
             .setTitle("Organize Forecast Links")
@@ -255,14 +251,12 @@ class HomeFragment : Fragment() {
             .setPositiveButton("OK") { dialog, _ ->
                 val sortBy = getSpinnerValue(spinnerSortBy, R.array.options_sort_by_values)
                 val separation = getSpinnerValue(spinnerSeparation, R.array.options_separation_values)
-//                val custom = getSpinnerValue(spinnerCustomOptions, R.array.options_custom_values)
                 val dragDropState = if (isDragDropEnabled) "enabled" else "disabled"
 
                 // Save the selected settings to SharedPreferences
                 with(sharedPreferences.edit()) {
                     putString("sortBy", sortBy)
                     putString("separation", separation)
-//                    putString("custom", custom)
                     putString("dragDrop", dragDropState)
                     apply()
                 }

--- a/app/src/main/res/drawable/baseline_drag_indicator_24.xml
+++ b/app/src/main/res/drawable/baseline_drag_indicator_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M11,18c0,1.1 -0.9,2 -2,2s-2,-0.9 -2,-2 0.9,-2 2,-2 2,0.9 2,2zM9,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM9,4c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM15,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM15,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM15,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z"/>
+    
+</vector>

--- a/app/src/main/res/layout/dialog_organize_links.xml
+++ b/app/src/main/res/layout/dialog_organize_links.xml
@@ -48,6 +48,6 @@
         android:id="@+id/switch_drag_n_drop"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Drag and Drop" />
+        android:text="@string/pref_dragdrop_title" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_organize_links.xml
+++ b/app/src/main/res/layout/dialog_organize_links.xml
@@ -31,17 +31,23 @@
         android:entries="@array/options_separation_entries"
         android:layout_marginBottom="16dp" />
 
-    <TextView
+<!--    <TextView-->
+<!--        android:layout_width="wrap_content"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        android:text="@string/pref_custom_title"-->
+<!--        android:layout_marginBottom="8dp" />-->
+
+<!--    <Spinner-->
+<!--        android:id="@+id/spinner_custom"-->
+<!--        android:layout_width="match_parent"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        android:entries="@array/options_custom_entries"-->
+<!--        android:layout_marginBottom="16dp" />-->
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/switch_drag_n_drop"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/pref_custom_title"
-        android:layout_marginBottom="8dp" />
-
-    <Spinner
-        android:id="@+id/spinner_custom"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:entries="@array/options_custom_entries"
-        android:layout_marginBottom="16dp" />
+        android:text="Drag and Drop" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/forecast_link_list_item.xml
+++ b/app/src/main/res/layout/forecast_link_list_item.xml
@@ -8,17 +8,37 @@
     app:cardElevation="4dp"
     app:cardCornerRadius="8dp"
     app:cardBackgroundColor="@color/medium_blue">
-
-    <TextView
-        android:id="@+id/tv_forecast_name"
+    
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="center"
-        android:paddingHorizontal="16dp"
-        android:paddingVertical="26dp"
-        android:textSize="18sp"
-        android:textColor="@color/white"
-        />
+        android:padding="8dp">
 
+        <TextView
+            android:id="@+id/tv_forecast_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="26dp"
+            android:textSize="18sp"
+            android:textColor="@color/white"
+            app:layout_constraintStart_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/iv_drag_indicator"
+            />
+
+        <ImageView
+            android:id="@+id/iv_drag_indicator"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/baseline_drag_indicator_24"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,11 +66,13 @@
     <string name="spinner_sort_by_title">Sort by</string>
     <string name="spinner_separation_title">Separation</string>
     <string name="pref_custom_title">Custom</string>
+    <string name="pref_dragdrop_title">Drag and Drop</string>
 
     <!-- Organize Forecast List keys -->
     <string name="pref_sort_key">sort</string>
     <string name="pref_separate_key">separate</string>
     <string name="pref_custom_key">custom</string>
+    <string name="pref_dragdrop_key">dragdrop</string>
     
     <!-- Sort by options -->
     <string name="pref_sort_entry_alphabet">Alphabetically</string>


### PR DESCRIPTION
The Organize Forecast List setting now utilizes a switch to enable/disable drag and drop organization. If the user activates Drag and Drop, the other settings are disabled (displayed in grey). If the user selects OK, drag handles appear on each Forecast item. The user can then implement custom organization. The order is saved in `SharedPreferences` so that if the user switches back to a preset organization by deactivating Drag and Drop, the order is saved for when the user reactivates Drag and Drop. 

Closes #33 

<img width="292" alt="image" src="https://github.com/user-attachments/assets/6abdb5fe-086f-43d1-b824-4407267de20a">
<img width="254" alt="image" src="https://github.com/user-attachments/assets/5ada42b2-bc83-4802-b257-d80042be25b1">
<img width="256" alt="image" src="https://github.com/user-attachments/assets/3697145e-ab7a-46bb-9aad-ef98629659a2">
<img width="308" alt="image" src="https://github.com/user-attachments/assets/d97af68c-0ea5-4be9-933f-a7a19358e5ae">

