### PR TITLE
Update themes.xml to apply dark mode to AppBarOverlay

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2024-06-22T00:33:19.120814Z">
+        <DropdownSelection timestamp="2024-08-31T19:12:41.849606Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/Users/sweis/.android/avd/Pixel_8_API_UpsideDownCakePrivacySandbox.avd" />

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -14,4 +14,14 @@
         <!-- Customize your theme here. -->
         <item name="android:divider">@color/list_divider</item>
     </style>
+
+    <!-- No ActionBar theme -->
+    <style name="Theme.VolcanoSeason3.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+    <!-- Overlay themes -->
+    <style name="Theme.VolcanoSeason3.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+    <style name="Theme.VolcanoSeason3.PopupOverlay" parent="ThemeOverlay.AppCompat.Dark" />
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -15,12 +15,13 @@
         <item name="android:divider">@color/list_divider_night</item>
     </style>
 
+    <!-- No ActionBar theme -->
     <style name="Theme.VolcanoSeason3.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>
 
+    <!-- Overlay themes -->
     <style name="Theme.VolcanoSeason3.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
-
     <style name="Theme.VolcanoSeason3.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 </resources>


### PR DESCRIPTION
The settings menu now properly adapts to dark mode.
![image](https://github.com/user-attachments/assets/3c4ec08a-486f-4865-9827-ac2e8b22473a)

Closes #38 