### PR TITLE
Move add-a-link button to left side

### DIFF
--- a/app/src/main/res/layout/app_bar_main.xml
+++ b/app/src/main/res/layout/app_bar_main.xml
@@ -26,7 +26,7 @@
         android:id="@+id/fab"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom|end"
+        android:layout_gravity="bottom|left"
         android:layout_marginEnd="@dimen/fab_margin"
         android:layout_marginBottom="16dp"
         android:backgroundTint="@color/light_blue"


### PR DESCRIPTION
The button no longer gets in the way of the drag and drop handles. 
<img width="296" alt="image" src="https://github.com/user-attachments/assets/544c0da3-0780-44a8-8f1d-71848223979e">

Closes #41 