### PR TITLE
Increase Forecast link font size

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2024-08-31T19:12:41.849606Z">
+        <DropdownSelection timestamp="2024-09-02T15:12:46.789210Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/sweis/.android/avd/Pixel_8_API_UpsideDownCakePrivacySandbox.avd" />
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=3A260DLJH0009A" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/src/main/res/layout/forecast_link_list_item.xml
+++ b/app/src/main/res/layout/forecast_link_list_item.xml
@@ -31,8 +31,9 @@
 
         <ImageView
             android:id="@+id/iv_drag_indicator"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:scaleType="fitCenter"
             android:src="@drawable/baseline_drag_indicator_24"
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/forecast_link_list_item.xml
+++ b/app/src/main/res/layout/forecast_link_list_item.xml
@@ -21,7 +21,7 @@
             android:gravity="center"
             android:paddingHorizontal="16dp"
             android:paddingVertical="26dp"
-            android:textSize="18sp"
+            android:textSize="20sp"
             android:textColor="@color/white"
             app:layout_constraintStart_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
Increased the text size of the Forecast link item and the size of the drag handle for better UI/UX

<img width="312" alt="image" src="https://github.com/user-attachments/assets/1fd7ac9d-1633-4695-9923-75a49c488744">

Closes #37 