### PR TITLE
Add duplicate check to populateDefaultForecastLinks

### DIFF
--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -238,6 +238,9 @@ class HomeFragment : Fragment() {
         val regionEmoji: String = getString(R.string.emoji_region)
         val defaultForecastLinks = ArrayList(
             linkNames.zip(links) { name, link ->
+                // Use "NOAA" as a flag to differentiate between volcanoes and regions.
+                // The idea is that volcanoes use mountain-forecast.com and
+                // regions use NOAA.
                 if (name.contains("NOAA")) {
                     ForecastLink(name = name, url = link, emoji = regionEmoji)
                 } else {

--- a/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/home/HomeFragment.kt
@@ -236,6 +236,10 @@ class HomeFragment : Fragment() {
         val links : Array<String> = resources.getStringArray(R.array.forecast_links)
         val volcanoEmoji : String = getString(R.string.emoji_volcano)
         val regionEmoji: String = getString(R.string.emoji_region)
+
+        val existingLinks = viewModel.forecastLinks.value ?: emptyList()
+        val existingLinkNames = existingLinks.map { it.name }
+
         val defaultForecastLinks = ArrayList(
             linkNames.zip(links) { name, link ->
                 // Use "NOAA" as a flag to differentiate between volcanoes and regions.
@@ -248,8 +252,13 @@ class HomeFragment : Fragment() {
                 }
             }.toList()
         )
+
         defaultForecastLinks.forEach { link ->
-            viewModel.addForecastLink(link)
+            if (!existingLinkNames.any { it.equals(link.name, ignoreCase = true) }) {
+                viewModel.addForecastLink(link)
+            } else {
+                Log.d("HomeFragment", "Skipping duplicate default link ${link.name}")
+            }
         }
     }
 


### PR DESCRIPTION
The function `populateDefaultForecastLinks` now contains a check to discard default links that match the name of an existing link in the view model. 