### PR TITLE
Update checklist headings

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-03-09T00:54:07.027884Z">
+        <DropdownSelection timestamp="2025-03-30T22:55:29.892727Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/Users/sweis/.android/avd/Pixel_8_API_VanillaIceCream.avd" />

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2024-12-10T05:12:27.679431Z">
+        <DropdownSelection timestamp="2025-03-09T00:54:07.027884Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/Users/sweis/.android/avd/Pixel_8_API_VanillaIceCream.avd" />

--- a/.idea/other.xml
+++ b/.idea/other.xml
@@ -292,6 +292,17 @@
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="samsung" />
+          <option name="codename" value="gta9pwifi" />
+          <option name="id" value="gta9pwifi" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="SM-X210" />
+          <option name="screenDensity" value="240" />
+          <option name="screenX" value="1200" />
+          <option name="screenY" value="1920" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
           <option name="codename" value="gts7xllite" />
           <option name="id" value="gts7xllite" />
           <option name="manufacturer" value="Samsung" />
@@ -512,6 +523,17 @@
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="tokay" />
+          <option name="id" value="tokay" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2424" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
           <option name="brand" value="google" />
           <option name="codename" value="tokay" />
           <option name="id" value="tokay" />

--- a/app/src/main/java/com/example/volcanoseason3/ui/checklist/ChecklistAdapter.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/checklist/ChecklistAdapter.kt
@@ -31,7 +31,11 @@ class ChecklistAdapter(
     }
 
     sealed class ListItem {
-        data class Header(val category: String) : ListItem()
+        data class Header(
+            val category: String,
+            val checkedCount: Int,
+            val totalCount: Int
+        ) : ListItem()
         data class Item(val checklistItem: ChecklistItem) : ListItem()
     }
 
@@ -82,10 +86,12 @@ class ChecklistAdapter(
 
     inner class HeaderViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         private val headerText: TextView = itemView.findViewById(R.id.tv_header)
+        private val countText: TextView = itemView.findViewById(R.id.tv_count)
         private val expandCollapseIcon: ImageView = itemView.findViewById(R.id.iv_expand_collapse)
 
         fun bind(header: ListItem.Header) {
             headerText.text = header.category
+            countText.text = "(${header.checkedCount} / ${header.totalCount})"
             val isExpanded = expandedCategories.contains(header.category)
 
             // Update the expand/collapse icon

--- a/app/src/main/java/com/example/volcanoseason3/ui/checklist/ChecklistAdapter.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/checklist/ChecklistAdapter.kt
@@ -91,9 +91,9 @@ class ChecklistAdapter(
             // Update the expand/collapse icon
             expandCollapseIcon.setImageResource(
                 if (isExpanded) {
-                    R.drawable.baseline_arrow_drop_up_24
-                } else {
                     R.drawable.baseline_arrow_drop_down_24
+                } else {
+                    R.drawable.baseline_arrow_right_24
                 }
             )
 
@@ -115,7 +115,7 @@ class ChecklistAdapter(
                     if (isExpanded) {
                         R.drawable.baseline_arrow_drop_down_24
                     } else {
-                        R.drawable.baseline_arrow_drop_up_24
+                        R.drawable.baseline_arrow_right_24
                     }
                 )
                 Log.d("ChecklistAdapter", "After update: $expandedCategories")

--- a/app/src/main/java/com/example/volcanoseason3/ui/checklist/ChecklistFragment.kt
+++ b/app/src/main/java/com/example/volcanoseason3/ui/checklist/ChecklistFragment.kt
@@ -73,10 +73,12 @@ class ChecklistFragment : Fragment(), ChecklistAdapter.CategoryStateListener {
 
             Log.d("ChecklistFragment", "Grouped items: $groupedItems")
             groupedItems.forEach { (category, checklistItems) ->
+                val checked = checklistItems.count { it.isChecked }
+                val total = checklistItems.size
                 val isExpanded = adapter.isCategoryExpanded(category)
                 Log.d("ChecklistFragment", "Processing category: $category, isExpanded: $isExpanded")
 
-                listItems.add(ChecklistAdapter.ListItem.Header(category))
+                listItems.add(ChecklistAdapter.ListItem.Header(category, checked, total))
                 if (isExpanded) {
                     Log.d("ChecklistFragment", "Adding items for category: $category")
                     listItems.addAll(checklistItems.map { ChecklistAdapter.ListItem.Item(it) })
@@ -146,7 +148,9 @@ class ChecklistFragment : Fragment(), ChecklistAdapter.CategoryStateListener {
         val listItems = mutableListOf<ChecklistAdapter.ListItem>()
 
         groupedItems.forEach { (category, checklistItems) ->
-            listItems.add(ChecklistAdapter.ListItem.Header(category))
+            val checked = checklistItems.count { it.isChecked }
+            val total = checklistItems.size
+            listItems.add(ChecklistAdapter.ListItem.Header(category, checked, total))
             if (adapter.isCategoryExpanded(category)) {
                 listItems.addAll(checklistItems.map { ChecklistAdapter.ListItem.Item(it) })
             }

--- a/app/src/main/res/drawable/baseline_arrow_right_24.xml
+++ b/app/src/main/res/drawable/baseline_arrow_right_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M10,17l5,-5 -5,-5v10z"/>
+    
+</vector>

--- a/app/src/main/res/layout/item_checklist_header.xml
+++ b/app/src/main/res/layout/item_checklist_header.xml
@@ -28,6 +28,7 @@
         app:layout_constraintStart_toEndOf="@id/iv_expand_collapse"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/tv_count"
         android:ellipsize="end"
         android:maxLines="1" />
 
@@ -38,7 +39,7 @@
         android:textSize="14sp"
         android:textColor="?android:textColorPrimary"
         android:paddingStart="8dp"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/tv_header"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent" />
     

--- a/app/src/main/res/layout/item_checklist_header.xml
+++ b/app/src/main/res/layout/item_checklist_header.xml
@@ -30,5 +30,16 @@
         app:layout_constraintBottom_toBottomOf="parent"
         android:ellipsize="end"
         android:maxLines="1" />
+
+    <TextView
+        android:id="@+id/tv_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="14sp"
+        android:textColor="?android:textColorPrimary"
+        android:paddingStart="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
     
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_checklist_header.xml
+++ b/app/src/main/res/layout/item_checklist_header.xml
@@ -5,7 +5,18 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="8dp">
-    
+
+    <ImageView
+        android:id="@+id/iv_expand_collapse"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/baseline_arrow_right_24"
+        app:tint="?attr/colorControlNormal"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:contentDescription="@string/expand_collapse_icon"  />
+
     <TextView
         android:id="@+id/tv_header"
         android:layout_width="wrap_content"
@@ -14,22 +25,10 @@
         android:textStyle="bold"
         android:theme="@style/Theme.AppCompat.DayNight"
         android:padding="8dp"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@id/iv_expand_collapse"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/iv_expand_collapse"
         android:ellipsize="end"
         android:maxLines="1" />
-
-    <ImageView
-        android:id="@+id/iv_expand_collapse"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/baseline_arrow_drop_down_24"
-        app:tint="?attr/colorControlNormal"
-        app:layout_constraintStart_toEndOf="@id/tv_header"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        android:contentDescription="@string/expand_collapse_icon"  />
     
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
The expandable arrow now resides on the left side of the checklist section headings and points to the right when collapsed and points down when expanded. 

A count ratio of checked / total now is also included in the section headings. 
<img width="196" alt="image" src="https://github.com/user-attachments/assets/b2f157b6-bcfe-432a-925b-f57a6d1b05b7" />

Closes #55 
Closes #56 